### PR TITLE
Improve lint configuration and cleanup imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,11 +21,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
-  'prettier/prettier': [
-    'error',
-    {
-      endOfLine: 'auto',
-    },
-  ],
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,8 @@ import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import * as bodyParser from 'body-parser';
-import rateLimit from 'express-rate-limit';
-import { ValidationPipe } from '@nestjs/common';
 import * as passport from 'passport';
 import { Request } from 'express';
-
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -37,18 +34,26 @@ async function bootstrap() {
   //   transform: true,
   // }));
   app.use(passport.initialize());
-  app.use('/payment/webhook', bodyParser.raw({ 
-    type: 'application/json',
-    limit: '500mb'
-  }));
-  app.use(bodyParser.json({ 
-    limit: '500mb',
-    verify: (req: Request, res, buf) => {
-      if (req.originalUrl === '/payment/webhook' || req.originalUrl === '/sumsub/webhook') {
-        (req as any).rawBody = buf;
-      }
-    }
-  }));
+  app.use(
+    '/payment/webhook',
+    bodyParser.raw({
+      type: 'application/json',
+      limit: '500mb',
+    }),
+  );
+  app.use(
+    bodyParser.json({
+      limit: '500mb',
+      verify: (req: Request, res, buf) => {
+        if (
+          req.originalUrl === '/payment/webhook' ||
+          req.originalUrl === '/sumsub/webhook'
+        ) {
+          (req as any).rawBody = buf;
+        }
+      },
+    }),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('API Documentation LilYou')
@@ -57,7 +62,6 @@ async function bootstrap() {
     .addBearerAuth()
     .build();
 
-  
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
 

--- a/src/utils/functions/createFile.ts
+++ b/src/utils/functions/createFile.ts
@@ -1,9 +1,13 @@
 import { extname } from 'path';
-import { v4 as uuidv4 } from 'uuid';
 import { promises as fs } from 'fs';
 import { BadRequestException } from '@nestjs/common';
 
-export const createFile = async (file: Express.Multer.File, userId: string, category: string,path?:string): Promise<string> => {
+export const createFile = async (
+  file: Express.Multer.File,
+  userId: string,
+  category: string,
+  path?: string,
+): Promise<string> => {
   try {
     // Check if file exists
     if (!file) {
@@ -11,16 +15,29 @@ export const createFile = async (file: Express.Multer.File, userId: string, cate
     }
     // Allowed file types
     const allowedTypes = [
-      'video/mp4', 'video/mpeg', 'video/quicktime', 'video/x-msvideo', 'video/x-ms-wmv',
-      'audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/midi', 'audio/x-midi',
-      'image/jpeg', 'image/png', 'image/gif', 'image/bmp', 'image/webp',
-      'application/pdf', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // xlsx
+      'video/mp4',
+      'video/mpeg',
+      'video/quicktime',
+      'video/x-msvideo',
+      'video/x-ms-wmv',
+      'audio/mpeg',
+      'audio/wav',
+      'audio/ogg',
+      'audio/midi',
+      'audio/x-midi',
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/bmp',
+      'image/webp',
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // xlsx
       'application/vnd.ms-excel', // xls
       'application/msword', // doc
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // docx
       'application/vnd.ms-powerpoint', // ppt
       'application/vnd.openxmlformats-officedocument.presentationml.presentation', // pptx
-      'application/octet-stream'
+      'application/octet-stream',
     ];
 
     // Check file type
@@ -29,10 +46,10 @@ export const createFile = async (file: Express.Multer.File, userId: string, cate
     }
 
     // Sanitize filename: replace all "_" with "-" and multiple hyphens with single one
-    let sanitizedFileName = file.originalname
-      .replace(/_/g, '-')  // Replace all underscores with hyphens
+    const sanitizedFileName = file.originalname
+      .replace(/_/g, '-') // Replace all underscores with hyphens
       .replace(/-+/g, '-') // Replace multiple hyphens with single one
-      .replace(/[^a-zA-Z0-9а-яА-ЯёЁ\-\. ]/g, '')  // Keep only allowed characters
+      .replace(/[^a-zA-Z0-9а-яА-ЯёЁ\-\. ]/g, '') // Keep only allowed characters
       .replace(/\s+/g, '-'); // Replace spaces with underscores
 
     // Get file extension
@@ -72,9 +89,8 @@ export const createFile = async (file: Express.Multer.File, userId: string, cate
     await fs.writeFile(filePath, file.buffer);
 
     return fileName + ext;
-
   } catch (error) {
     console.error('Error creating file:', error);
     throw new BadRequestException('An error occurred while uploading the file');
   }
-}
+};

--- a/src/utils/functions/sendEmail.ts
+++ b/src/utils/functions/sendEmail.ts
@@ -1,31 +1,38 @@
 import { BadRequestException } from '@nestjs/common';
 import * as nodemailer from 'nodemailer';
-const dotenv = require('dotenv');
+import * as dotenv from 'dotenv';
 dotenv.config();
 
 export const template = {
-    verify: (code: number) => `
-    <h1>Verification code: ${code}</h1>`
-}
+  verify: (code: number) => `
+    <h1>Verification code: ${code}</h1>`,
+};
 
-export async function sendEmail(to: string, subject: string, text: string): Promise<void> {
-  if(!to || !subject || !text){
-    throw new BadRequestException({code:400,message:'Email, subject and text are required'});
+export async function sendEmail(
+  to: string,
+  subject: string,
+  text: string,
+): Promise<void> {
+  if (!to || !subject || !text) {
+    throw new BadRequestException({
+      code: 400,
+      message: 'Email, subject and text are required',
+    });
   }
   const transporter = nodemailer.createTransport({
     host: process.env.SMTP_HOST,
     port: parseInt(process.env.SMTP_PORT),
     auth: {
       user: process.env.SMTP_USER,
-      pass: process.env.SMTP_PASSWORD
-    }
+      pass: process.env.SMTP_PASSWORD,
+    },
   });
 
   const mailOptions = {
     from: process.env.SMTP_FROM,
     to,
     subject,
-    html: text
+    html: text,
   };
 
   try {
@@ -36,4 +43,3 @@ export async function sendEmail(to: string, subject: string, text: string): Prom
     throw new Error('Failed to send email');
   }
 }
-

--- a/src/utils/functions/uploadFile.ts
+++ b/src/utils/functions/uploadFile.ts
@@ -2,7 +2,10 @@ import { BadRequestException } from '@nestjs/common';
 import { extname } from 'path';
 import { promises as fs } from 'fs';
 
-const uploadFile = async (file: Express.Multer.File, userId: string): Promise<string> => {
+const uploadFile = async (
+  file: Express.Multer.File,
+  userId: string,
+): Promise<string> => {
   try {
     // Проверяем наличие файла
     if (!file) {
@@ -13,25 +16,25 @@ const uploadFile = async (file: Express.Multer.File, userId: string): Promise<st
     const allowedTypes = [
       // Видео
       'video/mp4',
-      'video/mpeg', 
+      'video/mpeg',
       'video/quicktime',
       'video/x-msvideo',
       'video/x-ms-wmv',
-      
+
       // Музыка
       'audio/mpeg',
       'audio/wav',
       'audio/ogg',
       'audio/midi',
       'audio/x-midi',
-      
+
       // Фото
       'image/jpeg',
-      'image/png', 
+      'image/png',
       'image/gif',
       'image/bmp',
       'image/webp',
-      
+
       // Документы
       'application/pdf',
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // xlsx
@@ -39,7 +42,7 @@ const uploadFile = async (file: Express.Multer.File, userId: string): Promise<st
       'application/msword', // doc
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // docx
       'application/vnd.ms-powerpoint', // ppt
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation' // pptx
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation', // pptx
     ];
 
     // Проверяем тип файла
@@ -85,8 +88,7 @@ const uploadFile = async (file: Express.Multer.File, userId: string): Promise<st
     await fs.writeFile(`uploads/${fileName}`, file.buffer);
 
     return fileName;
-
-  } catch (error) {
+  } catch {
     throw new BadRequestException('Произошла ошибка при обновлении файла');
   }
 };


### PR DESCRIPTION
## Summary
- fix eslint config property location
- remove unused imports in `main.ts`
- cleanup fs usage in `PreviewService`
- remove unused uuid import
- switch to ES module import in email helper
- tidy error catch in file upload helper

## Testing
- `npx eslint src/main.ts src/preview/preview.service.ts src/utils/functions/createFile.ts src/utils/functions/sendEmail.ts src/utils/functions/uploadFile.ts`
- `npm run test:e2e` *(fails: Cannot find module '@/order/entities/order.entity')*

------
https://chatgpt.com/codex/tasks/task_e_68442f13ce708325ab3c4763a1c19f19