### PR TITLE
Add setup instructions and install helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+**/node_modules/
+
+# logs
+npm-debug.log*
+
+# OS generated
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# 3D Project
+
+This repository contains two main parts:
+
+- `backend` - NestJS backend application
+- `frontend` - Next.js frontend application
+
+## Installing dependencies
+
+Before running the tests with `npm test`, you must install the project dependencies. Run the following command inside the target directory:
+
+```bash
+npm install
+```
+
+For convenience, you can execute the provided `install.sh` script from the repository root to install dependencies for both the backend and frontend:
+
+```bash
+./install.sh
+```
+
+## Running tests
+
+Tests are located in the `backend` project. After installing dependencies, run:
+
+```bash
+cd backend
+npm test
+```
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Simple helper script to install Node.js dependencies for all subprojects
+
+set -e
+
+if [ -d "backend" ]; then
+  echo "Installing backend dependencies..."
+  (cd backend && npm install)
+fi
+
+if [ -d "frontend" ]; then
+  echo "Installing frontend dependencies..."
+  (cd frontend && npm install)
+fi
+
+echo "Installation complete."


### PR DESCRIPTION
## Summary
- document running `npm install` before `npm test`
- provide `install.sh` helper for installing backend and frontend dependencies
- ignore `node_modules` directories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684435a43ad48325ab369d83aaac8917