### PR TITLE
Fix defaultTheme import

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'tailwindcss';
-import { fontFamily } from 'tailwindcss/defaultTheme';
+import defaultTheme from 'tailwindcss/defaultTheme';
 const config: Config = {
   content: [
     './app/**/*.{ts,tsx}',
@@ -8,8 +8,8 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-inter)', ...(fontFamily.sans as string[])],
-        display: ['var(--font-poppins)', ...(fontFamily.sans as string[])],
+        sans: ['var(--font-inter)', ...(defaultTheme.fontFamily.sans as string[])],
+        display: ['var(--font-poppins)', ...(defaultTheme.fontFamily.sans as string[])],
       },
     },
   },


### PR DESCRIPTION
## Summary
- import default theme correctly in Next.js Tailwind config

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68443d4c0b50832593932d6947c26acd