### PR TITLE
Add env variable sanity tests

### DIFF
--- a/backend/src/env-vars.spec.ts
+++ b/backend/src/env-vars.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from '@jest/globals';
+
+// List of required environment variables
+const requiredEnvVars = [
+  'TELEGRAM_BOT_TOKEN',
+  'DB_HOST',
+  'DB_PORT',
+  'DB_USERNAME',
+  'DB_PASSWORD',
+  'DB_NAME',
+  'OPENAI_API_KEY',
+  'API_URL',
+  'FRONTEND_URL',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'SMTP_HOST',
+  'SMTP_PORT',
+  'SMTP_USER',
+  'SMTP_PASSWORD',
+  'SMTP_FROM',
+  'TELEGRAM_BOT_PASSWORD',
+  'TELEGRAM_ADMIN_CHAT_ID',
+];
+
+describe('Environment variables', () => {
+  for (const envVar of requiredEnvVars) {
+    it(`should have ${envVar} defined`, () => {
+      expect(process.env[envVar]).toBeDefined();
+      if (process.env[envVar]) {
+        expect(process.env[envVar]).not.toEqual('');
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- check backend environment variables in Jest before running

## Testing
- `bash install.sh`
- `cd backend && npm test` *(fails: missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_684454be89f4832594f780a21de88fcf