### PR TITLE
Add backend unit tests

### DIFF
--- a/backend/src/order/order.service.spec.ts
+++ b/backend/src/order/order.service.spec.ts
@@ -1,0 +1,59 @@
+import { OrderService } from './order.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+
+const mockRepository = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+});
+
+const mockStripeService = () => ({
+  createLink: jest.fn(),
+});
+
+describe('OrderService', () => {
+  let service: OrderService;
+  let repo: ReturnType<typeof mockRepository>;
+  let stripe: ReturnType<typeof mockStripeService>;
+
+  beforeEach(() => {
+    repo = mockRepository();
+    stripe = mockStripeService();
+    service = new OrderService(repo as any, stripe as any);
+  });
+
+  it('should create order and return payment url', async () => {
+    const dto: CreateOrderDto = {
+      first_name: 'John',
+      last_name: 'Doe',
+      email: 'test@test.com',
+      photo_id: '1',
+      shipping_address: 'addr',
+    };
+    const order = { id: 1, ...dto, status_order: 'pending', status_payment: 'unpaid' };
+    repo.create.mockReturnValue(order);
+    repo.save.mockResolvedValue(order);
+    stripe.createLink.mockResolvedValue('url');
+
+    const result = await service.create(dto);
+    expect(repo.create).toHaveBeenCalledWith({
+      ...dto,
+      status_order: 'pending',
+      status_payment: 'unpaid',
+    });
+    expect(stripe.createLink).toHaveBeenCalledWith(order.id);
+    expect(result).toEqual({ success: true, order, paymentUrl: 'url' });
+  });
+
+  it('should throw error when repository fails', async () => {
+    const dto: CreateOrderDto = {
+      first_name: 'John',
+      last_name: 'Doe',
+      email: 'test@test.com',
+      photo_id: '1',
+      shipping_address: 'addr',
+    };
+    repo.create.mockReturnValue(dto);
+    repo.save.mockRejectedValue(new Error('fail'));
+    await expect(service.create(dto)).rejects.toThrow('fail');
+  });
+});

--- a/backend/src/preview/preview.service.spec.ts
+++ b/backend/src/preview/preview.service.spec.ts
@@ -1,0 +1,97 @@
+import { PreviewService } from './preview.service';
+import { TempGeneratePhoto } from './entities/temp-generate-photo.entity';
+
+const repoMock = () => ({
+  create: jest.fn(),
+  save: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+});
+
+const notificationMock = () => ({
+  sendMessageToSubscribers: jest.fn(),
+});
+
+describe('PreviewService', () => {
+  let service: PreviewService;
+  let repo: ReturnType<typeof repoMock>;
+  let notify: ReturnType<typeof notificationMock>;
+
+  beforeEach(() => {
+    repo = repoMock();
+    notify = notificationMock();
+    service = new PreviewService({} as any, repo as any, notify as any);
+    jest.spyOn<any, any>(service as any, 'generateStarterPack').mockResolvedValue({
+      file_name: 'name.png',
+      file_path: '/tmp/name.png',
+    });
+    process.env.API_URL = 'http://localhost';
+  });
+
+  it('create should save photo and return data', async () => {
+    repo.create.mockReturnValue({} as TempGeneratePhoto);
+    repo.save.mockResolvedValue({ id: 1, file_name: 'name.png', file_path: '/tmp/name.png' });
+
+    const file: Express.Multer.File = {
+      buffer: Buffer.from('1'),
+      mimetype: 'image/png',
+      originalname: 'test.png',
+      size: 10,
+      fieldname: '',
+      stream: null,
+      destination: '',
+      encoding: '7bit',
+      filename: '',
+      path: '',
+    } as any;
+
+    const result = await service.create(file);
+    expect(repo.save).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.data.url).toBe('http://localhost/preview/temp-photos/1');
+  });
+
+  it('create should fail with wrong mime', async () => {
+    const file: Express.Multer.File = {
+      buffer: Buffer.from('1'),
+      mimetype: 'text/plain',
+      originalname: 'test.txt',
+      size: 10,
+      fieldname: '',
+      stream: null,
+      destination: '',
+      encoding: '7bit',
+      filename: '',
+      path: '',
+    } as any;
+
+    const result = await service.create(file);
+    expect(result.success).toBe(false);
+  });
+
+  it('getTempPhoto should return url', async () => {
+    repo.findOne.mockResolvedValue({ id: 1, file_name: 'name.png' });
+    const result = await service.getTempPhoto(1);
+    expect(result.success).toBe(true);
+    expect(result.data.url_image).toBe('http://localhost/uploads/temp-photos/name.png');
+  });
+
+  it('getTempPhoto should handle not found', async () => {
+    repo.findOne.mockResolvedValue(undefined);
+    const result = await service.getTempPhoto(1);
+    expect(result.success).toBe(false);
+  });
+
+  it('getLatestPhotos should map photos', async () => {
+    const photos = [
+      { id: 1, file_name: 'name.png', created_at: new Date() },
+    ];
+    repo.find.mockResolvedValue(photos);
+    const res = await service.getLatestPhotos(1);
+    expect(res[0]).toMatchObject({
+      id: 1,
+      title: 'name.png',
+      imageUrl: 'http://localhost/uploads/temp-photos/name.png',
+    });
+  });
+});

--- a/backend/src/stripe/stripe.service.spec.ts
+++ b/backend/src/stripe/stripe.service.spec.ts
@@ -1,0 +1,73 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { StripeService } from './stripe.service';
+
+const mockStripe = {
+  checkout: { sessions: { create: jest.fn() } },
+  paymentLinks: { update: jest.fn() },
+  webhooks: { constructEvent: jest.fn() },
+};
+
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => mockStripe),
+  };
+});
+
+describe('StripeService', () => {
+  const orderRepo = {
+    findOne: jest.fn(),
+    update: jest.fn(),
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STRIPE_SECRET_KEY = 'key';
+  });
+
+  it('createLink should return url', async () => {
+    mockStripe.checkout.sessions.create.mockResolvedValue({ url: 'u' });
+    const service = new StripeService(orderRepo);
+    const url = await service.createLink(1);
+    expect(mockStripe.checkout.sessions.create).toHaveBeenCalled();
+    expect(url).toBe('u');
+  });
+
+  it('deactivateLink should call update', async () => {
+    const service = new StripeService(orderRepo);
+    await service.deactivateLink('id');
+    expect(mockStripe.paymentLinks.update).toHaveBeenCalledWith('id', { active: false });
+  });
+
+  it('acceptPayment should update order status', async () => {
+    const service = new StripeService(orderRepo);
+    const spy = jest.spyOn<any, any>(service as any, 'updateOrderStatus').mockResolvedValue(undefined);
+    await service.acceptPayment({ metadata: { orderId: '1' } } as any);
+    expect(spy).toHaveBeenCalledWith('1', 'paid');
+  });
+
+  it('rejectPayment should update order status', async () => {
+    const service = new StripeService(orderRepo);
+    const spy = jest.spyOn<any, any>(service as any, 'updateOrderStatus').mockResolvedValue(undefined);
+    await service.rejectPayment({ metadata: { orderId: '1' } } as any);
+    expect(spy).toHaveBeenCalledWith('1', 'failed');
+  });
+
+  it('handleWebhook should process event', async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = 'secret';
+    mockStripe.webhooks.constructEvent.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: { object: { metadata: { orderId: '1' } } },
+    });
+    const service = new StripeService(orderRepo);
+    jest.spyOn(service, 'acceptPayment').mockResolvedValue(undefined);
+    const result = await service.handleWebhook('sig', Buffer.from(''));
+    expect(result).toEqual({ received: true });
+    expect(service.acceptPayment).toHaveBeenCalled();
+  });
+
+  it('startStripe throws without key', () => {
+    delete process.env.STRIPE_SECRET_KEY;
+    expect(() => new StripeService(orderRepo)).toThrow(InternalServerErrorException);
+  });
+});

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,0 +1,112 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { UserService } from './user.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { User } from './entities/user.entity';
+
+const mockRepository = () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+  remove: jest.fn(),
+});
+
+describe('UserService', () => {
+  let service: UserService;
+  let repo: ReturnType<typeof mockRepository>;
+
+  beforeEach(() => {
+    repo = mockRepository();
+    service = new UserService(repo as any);
+  });
+
+  describe('create', () => {
+    it('should create a user when email does not exist', async () => {
+      repo.findOne.mockResolvedValue(undefined);
+      repo.create.mockReturnValue({} as User);
+      repo.save.mockResolvedValue({ id: '1' } as User);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed');
+
+      const dto: CreateUserDto = {
+        email: 'test@test.com',
+        password: 'password',
+        firstName: 'John',
+        lastName: 'Doe',
+      };
+      const result = await service.create(dto);
+      expect(repo.create).toHaveBeenCalledWith({
+        ...dto,
+        password: 'hashed',
+      });
+      expect(repo.save).toHaveBeenCalled();
+      expect(result).toEqual({ id: '1' });
+    });
+
+    it('should throw ConflictException if email exists', async () => {
+      repo.findOne.mockResolvedValue({ id: '1' });
+      const dto: CreateUserDto = {
+        email: 'test@test.com',
+        password: 'password',
+        firstName: 'John',
+        lastName: 'Doe',
+      };
+      await expect(service.create(dto)).rejects.toBeInstanceOf(ConflictException);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return user when found', async () => {
+      repo.findOne.mockResolvedValue({ id: '1' });
+      const result = await service.findOne('1');
+      expect(result).toEqual({ id: '1' });
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      repo.findOne.mockResolvedValue(undefined);
+      await expect(service.findOne('1')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should hash password and save', async () => {
+      const user = { id: '1', password: 'old' } as User;
+      repo.findOne.mockResolvedValue(user);
+      jest.spyOn(bcrypt, 'hash').mockResolvedValue('hashed');
+      repo.save.mockResolvedValue({ ...user, password: 'hashed' });
+
+      const dto: UpdateUserDto = { password: 'new' } as any;
+      const result = await service.update('1', dto);
+      expect(result.password).toBe('hashed');
+      expect(repo.save).toHaveBeenCalledWith({ ...user, password: 'hashed' });
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove user', async () => {
+      const user = { id: '1' } as User;
+      repo.findOne.mockResolvedValue(user);
+      await service.remove('1');
+      expect(repo.remove).toHaveBeenCalledWith(user);
+    });
+  });
+
+  describe('getLatestModels', () => {
+    it('should return mapped models', async () => {
+      const users = [
+        { id: '1', firstName: 'a', lastName: 'b', modelTitle: 't', modelImageUrl: 'img', modelUrl: 'url', createdAt: new Date() },
+      ];
+      repo.find.mockResolvedValue(users);
+      const result = await service.getLatestModels(1);
+      expect(result[0]).toMatchObject({
+        id: '1',
+        firstName: 'a',
+        lastName: 'b',
+        modelTitle: 't',
+        modelImageUrl: 'img',
+        modelUrl: 'url',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for backend services
- increase theoretical coverage over core business logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445aebdee883259719c43052d0eb49